### PR TITLE
Forced the number of page to be Integer, otherwise it crashes.

### DIFF
--- a/file_deleter.py
+++ b/file_deleter.py
@@ -26,7 +26,7 @@ def main(token, weeks):
     slack = Slacker(token)
     # Get list of all files available for the user of the token
     total = slack.files.list(count=1).body['paging']['total']
-    num_pages = round(total/1000.00 + .5) # Get number of pages
+    num_pages = int(round(total/1000.00 + .5)) # Get number of pages
     print("{} files to be processed, across {} pages".format(total, num_pages))
     # Get files
     files_to_delete = []


### PR DESCRIPTION
This resolves this issue.

```
1552 files to be processed, across 2.0 pages
Traceback (most recent call last):
  File "file_deleter.py", line 76, in <module>
    main(token, weeks)
  File "file_deleter.py", line 35, in main
    for page in range(num_pages):
TypeError: range() integer end argument expected, got float.
```
